### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The SuperCollider MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server for the SuperCollider programming language that allows to execute synth using supercolliderjs.
 
+<a href="https://glama.ai/mcp/servers/@Synohara/supercollider-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Synohara/supercollider-mcp/badge" alt="supercollider-mcp MCP server" />
+</a>
+
 ## Prerequisites
 
 1. Install [SuperCollider](https://supercollider.github.io/downloads) on your machine.


### PR DESCRIPTION
This PR adds a badge for the [supercollider-mcp](https://glama.ai/mcp/servers/@Synohara/supercollider-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Synohara/supercollider-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Synohara/supercollider-mcp/badge" alt="supercollider-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.